### PR TITLE
Feature: Replace local Vault with just ExternalSecretsOperator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ talos-config: bin/talosctl $(OUTPUT_DIR)/talos-secrets.yaml kustomize
 		--output-dir "$(OUTPUT_DIR)" \
 		--with-secrets "$(OUTPUT_DIR)/talos-secrets.yaml"
 	yq eval $(YQ_ARGS) '.machine.network.interfaces[0].addresses[0] = "$(NODE_IP)/24"'                       $(TALOS_NODECONF)
-	yq eval $(YQ_ARGS) '.cluster.inlineManifests[0].contents = load_str("secrets/vault-secretid.yaml")' $(TALOS_NODECONF)
+	yq eval $(YQ_ARGS) '.cluster.inlineManifests[0].contents = load_str("secrets/eso-k8s-token.yaml")' $(TALOS_NODECONF)
 	yq eval $(YQ_ARGS) '.cluster.inlineManifests[1].contents = load_str("$(OUTPUT_DIR)/infra-argocd.yaml")'  $(TALOS_NODECONF)
 	yq eval $(YQ_ARGS) '.cluster.inlineManifests[2].contents = load_str("$(OUTPUT_DIR)//infra-cillium.yaml")'  $(TALOS_NODECONF)
 	yq eval $(YQ_ARGS) '.cluster.inlineManifests[3].contents = load_str("$(OUTPUT_DIR)/infra-traefik.yaml")'  $(TALOS_NODECONF)

--- a/gitops/argocd/additional_config/tls-ingress.yaml
+++ b/gitops/argocd/additional_config/tls-ingress.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-cluster
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: cert-argocd-buc-sh
@@ -15,7 +15,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
-      key: cert/cert-argocd-buc-sh
+      key: cert-argocd-buc-sh
 
 ---
 apiVersion: networking.k8s.io/v1

--- a/gitops/argocd/additional_config/tls-ingress.yaml
+++ b/gitops/argocd/additional_config/tls-ingress.yaml
@@ -15,6 +15,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
+      metadataPolicy: None
       key: cert-argocd-buc-sh
 
 ---

--- a/gitops/argocd/base/apps.yaml
+++ b/gitops/argocd/base/apps.yaml
@@ -8,7 +8,7 @@ spec:
       elements:
       # == Cluster Infra ===
       - name: external-secrets
-        rev: feat-remove-vault
+        rev: main
         path: gitops/external-secrets/base
         wave: "1"
       - name: argocd
@@ -33,11 +33,11 @@ spec:
         wave: "1"
       # === Apps ===
       - name: paperless
-        rev: feat-remove-vault
+        rev: main
         path: gitops/paperless
         wave: "2"
       - name: syncthing
-        rev: feat-remove-vault
+        rev: main
         path: gitops/syncthing
         wave: "2"
       - name: spdf
@@ -46,11 +46,11 @@ spec:
         wave: "1"
       # === Internet Facing
       - name: ntfy
-        rev: feat-remove-vault
+        rev: main
         path: gitops/ntfy
         wave: "2"
       - name: external-http
-        rev: feat-remove-vault
+        rev: main
         path: gitops/external-http
         wave: "2"
       - name: external-homelabapi
@@ -58,7 +58,7 @@ spec:
         path: gitops/external-homelabapi
         wave: "2"
       - name: external-r2
-        rev: feat-remove-vault
+        rev: main
         path: gitops/external-r2
         wave: "2"
   template:

--- a/gitops/external-http/envoy.yaml
+++ b/gitops/external-http/envoy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-cluster
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: cert-cloud-buc-sh
@@ -15,7 +15,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
-      key: cert/cert-secure-http-buc-sh
+      key: cert-secure-http-buc-sh
 
 ---
 apiVersion: apps/v1

--- a/gitops/external-http/envoy.yaml
+++ b/gitops/external-http/envoy.yaml
@@ -15,6 +15,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
+      metadataPolicy: None
       key: cert-secure-http-buc-sh
 
 ---

--- a/gitops/external-r2/deploy.yaml
+++ b/gitops/external-r2/deploy.yaml
@@ -27,12 +27,14 @@ spec:
       property: s3_ro_accesskey
       conversionStrategy: Default
       decodingStrategy: None
+      metadataPolicy: None
   - secretKey: SECRET_ACCESS_KEY
     remoteRef:
       key: static-secrets
       property: s3_ro_secretkey
       conversionStrategy: Default
       decodingStrategy: None
+      metadataPolicy: None
 
 ---
 apiVersion: apps/v1
@@ -137,6 +139,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
+      metadataPolicy: None
       key: cert-r2-buc-sh
 
 ---

--- a/gitops/external-r2/deploy.yaml
+++ b/gitops/external-r2/deploy.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-secret
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: eso-r2-creds
@@ -23,13 +23,13 @@ spec:
   data:
   - secretKey: ACCESS_KEY_ID
     remoteRef:
-      key: access/nas
+      key: static-secrets
       property: s3_ro_accesskey
       conversionStrategy: Default
       decodingStrategy: None
   - secretKey: SECRET_ACCESS_KEY
     remoteRef:
-      key: access/nas
+      key: static-secrets
       property: s3_ro_secretkey
       conversionStrategy: Default
       decodingStrategy: None
@@ -128,7 +128,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-cluster
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: cert-r2-buc-sh
@@ -137,7 +137,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
-      key: cert/cert-r2-buc-sh
+      key: cert-r2-buc-sh
 
 ---
 apiVersion: networking.k8s.io/v1

--- a/gitops/external-secrets/base/secret-stores.yaml
+++ b/gitops/external-secrets/base/secret-stores.yaml
@@ -69,3 +69,26 @@ spec:
         serviceAccount:
           name: external-secrets
           namespace: external-secrets
+
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: k8s-evergreen
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: external-secrets       # Namespace where the bearer token secret is stored
+      server:
+        url: "https://10.0.0.16:6443"
+        caProvider:
+          type: secret
+          name: evergreen-token
+          namespace: external-secrets
+          key: ca.crt
+      auth:
+        token:
+          bearerToken:
+            name: evergreen-token
+            key: token
+

--- a/gitops/external-secrets/base/secret-stores.yaml
+++ b/gitops/external-secrets/base/secret-stores.yaml
@@ -109,6 +109,12 @@ spec:
     name: cert-grafana-buc-sh
     creationPolicy: Owner
   dataFrom:
-  - find:
-      name:
-        regexp: "cert-grafana-buc-sh"
+  # - find:
+  #     conversionStrategy: Default
+  #     decodingStrategy: None
+  #     name:
+  #       regexp: "cert-grafana-buc-sh"
+    - extract:
+      conversionStrategy: Default
+      decodingStrategy: None
+      key: cert/cert-grafana-buc-sh

--- a/gitops/external-secrets/base/secret-stores.yaml
+++ b/gitops/external-secrets/base/secret-stores.yaml
@@ -8,7 +8,6 @@ apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: vault-approle-cluster
-  namespace: external-secrets
   annotations:
      argocd.argoproj.io/sync-wave: "2"
 spec:
@@ -31,7 +30,6 @@ apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: vault-approle-secret
-  namespace: external-secrets
   annotations:
      argocd.argoproj.io/sync-wave: "2"
 spec:
@@ -54,6 +52,8 @@ apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
   name: cluster-local
+  annotations:
+     argocd.argoproj.io/sync-wave: "2"
 spec:
   provider:
     kubernetes:
@@ -74,11 +74,13 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
-  name: k8s-evergreen
+  name: k8s-evergreen-prod
+  annotations:
+     argocd.argoproj.io/sync-wave: "2"
 spec:
   provider:
     kubernetes:
-      remoteNamespace: prod-secrets
+      remoteNamespace: prod
       server:
         url: "https://10.0.0.16:6443"
         caProvider:
@@ -92,4 +94,22 @@ spec:
             name: evergreen-token
             namespace: external-secrets
             key: token
-
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: test-k8s-css
+  namespace: external-secrets
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: k8s-evergreen-prod
+    kind: ClusterSecretStore
+  target:
+    name: cert-grafana-buc-sh
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      conversionStrategy: Default
+      decodingStrategy: None
+      key: cert-grafana-buc-sh

--- a/gitops/external-secrets/base/secret-stores.yaml
+++ b/gitops/external-secrets/base/secret-stores.yaml
@@ -114,7 +114,7 @@ spec:
   #     decodingStrategy: None
   #     name:
   #       regexp: "cert-grafana-buc-sh"
-    - extract:
+  - extract:
       conversionStrategy: Default
       decodingStrategy: None
-      key: cert/cert-grafana-buc-sh
+      key: cert-grafana-buc-sh

--- a/gitops/external-secrets/base/secret-stores.yaml
+++ b/gitops/external-secrets/base/secret-stores.yaml
@@ -82,7 +82,7 @@ spec:
       server:
         url: "https://10.0.0.16:6443"
         caProvider:
-          type: secret
+          type: Secret
           name: evergreen-token
           namespace: external-secrets
           key: ca.crt

--- a/gitops/external-secrets/base/secret-stores.yaml
+++ b/gitops/external-secrets/base/secret-stores.yaml
@@ -3,49 +3,49 @@ kind: Namespace
 metadata:
   name: external-secrets
 
----
-apiVersion: external-secrets.io/v1beta1
-kind: ClusterSecretStore
-metadata:
-  name: vault-approle-cluster
-  annotations:
-     argocd.argoproj.io/sync-wave: "2"
-spec:
-  provider:
-    vault:
-      server: "https://vault.buc.sh"
-      path: "cluster/"
-      version: "v2"
-      auth:
-        appRole:
-          path: "approle"
-          roleId: prod
-          secretRef:
-            name: "vault-secretid"
-            key: "secretid"
-            namespace: external-secrets
+# ---
+# apiVersion: external-secrets.io/v1beta1
+# kind: ClusterSecretStore
+# metadata:
+#   name: vault-approle-cluster
+#   annotations:
+#      argocd.argoproj.io/sync-wave: "2"
+# spec:
+#   provider:
+#     vault:
+#       server: "https://vault.buc.sh"
+#       path: "cluster/"
+#       version: "v2"
+#       auth:
+#         appRole:
+#           path: "approle"
+#           roleId: prod
+#           secretRef:
+#             name: "vault-secretid"
+#             key: "secretid"
+#             namespace: external-secrets
 
----
-apiVersion: external-secrets.io/v1beta1
-kind: ClusterSecretStore
-metadata:
-  name: vault-approle-secret
-  annotations:
-     argocd.argoproj.io/sync-wave: "2"
-spec:
-  provider:
-    vault:
-      server: "https://vault.buc.sh"
-      path: "secret/"
-      version: "v2"
-      auth:
-        appRole:
-          path: "approle"
-          roleId: prod
-          secretRef:
-            name: "vault-secretid"
-            key: "secretid"
-            namespace: external-secrets
+# ---
+# apiVersion: external-secrets.io/v1beta1
+# kind: ClusterSecretStore
+# metadata:
+#   name: vault-approle-secret
+#   annotations:
+#      argocd.argoproj.io/sync-wave: "2"
+# spec:
+#   provider:
+#     vault:
+#       server: "https://vault.buc.sh"
+#       path: "secret/"
+#       version: "v2"
+#       auth:
+#         appRole:
+#           path: "approle"
+#           roleId: prod
+#           secretRef:
+#             name: "vault-secretid"
+#             key: "secretid"
+#             namespace: external-secrets
 
 ---
 apiVersion: external-secrets.io/v1beta1

--- a/gitops/external-secrets/base/secret-stores.yaml
+++ b/gitops/external-secrets/base/secret-stores.yaml
@@ -78,7 +78,7 @@ metadata:
 spec:
   provider:
     kubernetes:
-      remoteNamespace: external-secrets       # Namespace where the bearer token secret is stored
+      remoteNamespace: prod-secrets
       server:
         url: "https://10.0.0.16:6443"
         caProvider:

--- a/gitops/external-secrets/base/secret-stores.yaml
+++ b/gitops/external-secrets/base/secret-stores.yaml
@@ -103,7 +103,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: k8s-evergreen-prod
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: cert-grafana-buc-sh

--- a/gitops/external-secrets/base/secret-stores.yaml
+++ b/gitops/external-secrets/base/secret-stores.yaml
@@ -94,27 +94,3 @@ spec:
             name: evergreen-token
             namespace: external-secrets
             key: token
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: test-k8s-css
-  namespace: external-secrets
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: k8s-evergreen
-    kind: ClusterSecretStore
-  target:
-    name: cert-grafana-buc-sh
-    creationPolicy: Owner
-  dataFrom:
-  # - find:
-  #     conversionStrategy: Default
-  #     decodingStrategy: None
-  #     name:
-  #       regexp: "cert-grafana-buc-sh"
-  - extract:
-      conversionStrategy: Default
-      decodingStrategy: None
-      key: cert-grafana-buc-sh

--- a/gitops/external-secrets/base/secret-stores.yaml
+++ b/gitops/external-secrets/base/secret-stores.yaml
@@ -3,50 +3,6 @@ kind: Namespace
 metadata:
   name: external-secrets
 
-# ---
-# apiVersion: external-secrets.io/v1beta1
-# kind: ClusterSecretStore
-# metadata:
-#   name: vault-approle-cluster
-#   annotations:
-#      argocd.argoproj.io/sync-wave: "2"
-# spec:
-#   provider:
-#     vault:
-#       server: "https://vault.buc.sh"
-#       path: "cluster/"
-#       version: "v2"
-#       auth:
-#         appRole:
-#           path: "approle"
-#           roleId: prod
-#           secretRef:
-#             name: "vault-secretid"
-#             key: "secretid"
-#             namespace: external-secrets
-
-# ---
-# apiVersion: external-secrets.io/v1beta1
-# kind: ClusterSecretStore
-# metadata:
-#   name: vault-approle-secret
-#   annotations:
-#      argocd.argoproj.io/sync-wave: "2"
-# spec:
-#   provider:
-#     vault:
-#       server: "https://vault.buc.sh"
-#       path: "secret/"
-#       version: "v2"
-#       auth:
-#         appRole:
-#           path: "approle"
-#           roleId: prod
-#           secretRef:
-#             name: "vault-secretid"
-#             key: "secretid"
-#             namespace: external-secrets
-
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore

--- a/gitops/external-secrets/base/secret-stores.yaml
+++ b/gitops/external-secrets/base/secret-stores.yaml
@@ -90,5 +90,6 @@ spec:
         token:
           bearerToken:
             name: evergreen-token
+            namespace: external-secrets
             key: token
 

--- a/gitops/external-secrets/base/secret-stores.yaml
+++ b/gitops/external-secrets/base/secret-stores.yaml
@@ -74,7 +74,7 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
-  name: k8s-evergreen-prod
+  name: k8s-evergreen
   annotations:
      argocd.argoproj.io/sync-wave: "2"
 spec:

--- a/gitops/external-secrets/base/secret-stores.yaml
+++ b/gitops/external-secrets/base/secret-stores.yaml
@@ -109,7 +109,6 @@ spec:
     name: cert-grafana-buc-sh
     creationPolicy: Owner
   dataFrom:
-  - extract:
-      conversionStrategy: Default
-      decodingStrategy: None
-      key: cert-grafana-buc-sh
+  - find:
+      name:
+        regexp: "cert-grafana-buc-sh"

--- a/gitops/monitoring/grafana/resources.yaml
+++ b/gitops/monitoring/grafana/resources.yaml
@@ -15,6 +15,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
+      metadataPolicy: None
       key: cert-grafana-buc-sh
 
 ---
@@ -36,12 +37,14 @@ spec:
     remoteRef:
       conversionStrategy: Default
       decodingStrategy: None
+      metadataPolicy: None
       key: static-secrets
       property: cred_admin_user
   - secretKey: password
     remoteRef:
       conversionStrategy: Default
       decodingStrategy: None
+      metadataPolicy: None
       key: static-secrets
       property: cred_admin_password
 

--- a/gitops/monitoring/grafana/resources.yaml
+++ b/gitops/monitoring/grafana/resources.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-cluster
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: cert-grafana-buc-sh
@@ -15,7 +15,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
-      key: cert/cert-grafana-buc-sh
+      key: cert-grafana-buc-sh
 
 ---
 apiVersion: external-secrets.io/v1beta1
@@ -26,7 +26,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-secret
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: grafana-admin-cred
@@ -36,13 +36,13 @@ spec:
     remoteRef:
       conversionStrategy: Default
       decodingStrategy: None
-      key: access/static-cred
+      key: static-secrets
       property: cred_admin_user
   - secretKey: password
     remoteRef:
       conversionStrategy: Default
       decodingStrategy: None
-      key: access/static-cred
+      key: static-secrets
       property: cred_admin_password
 
 ---

--- a/gitops/ntfy/ntfy-app.yaml
+++ b/gitops/ntfy/ntfy-app.yaml
@@ -85,7 +85,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-secret
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: ntfy-creds-vault
@@ -93,7 +93,7 @@ spec:
   data:
   - secretKey: BUC_PASSWORD
     remoteRef:
-      key: access/static-cred
+      key: static-secrets
       property: cred_admin_password
       conversionStrategy: Default
       decodingStrategy: None
@@ -121,7 +121,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: cluster-local
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: ntfy-creds-k8s
@@ -129,7 +129,7 @@ spec:
   data:
   - secretKey: PROD_CLUSTER_PASSWORD
     remoteRef:
-      key: cluster-secrets
+      key: prod-secretids
       property: prod
       conversionStrategy: Default
       decodingStrategy: None
@@ -255,7 +255,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-cluster
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: cert-push-buc-sh
@@ -264,8 +264,8 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
-      key: cert/cert-push-buc-sh
       metadataPolicy: None
+      key: cert-push-buc-sh
 
 ---
 apiVersion: networking.k8s.io/v1

--- a/gitops/okd-console/console.yaml
+++ b/gitops/okd-console/console.yaml
@@ -122,6 +122,25 @@ spec:
       targetPort: 9000
       protocol: TCP
 
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: okd-console-tls
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: k8s-evergreen
+    kind: ClusterSecretStore
+  target:
+    name: cert-prod-console-buc-sh
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      conversionStrategy: Default
+      decodingStrategy: None
+      metadataPolicy: None
+      key: cert-prod-console-buc-sh
 
 ---
 apiVersion: networking.k8s.io/v1
@@ -133,8 +152,8 @@ metadata:
 spec:
   tls:
   - hosts:
-    - prod-console.buc.sh
-    secretName: cert-evergreen-console-buc-sh
+      - prod-console.buc.sh
+    secretName: cert-prod-console-buc-sh
   rules:
   - host: prod-console.buc.sh
     http:

--- a/gitops/paperless/paperless-app.yaml
+++ b/gitops/paperless/paperless-app.yaml
@@ -47,12 +47,14 @@ spec:
       property: cred_admin_user
       conversionStrategy: Default
       decodingStrategy: None
+      metadataPolicy: None
   - secretKey: PAPERLESS_ADMIN_PASSWORD
     remoteRef:
       key: static-secrets
       property: cred_admin_password
       conversionStrategy: Default
       decodingStrategy: None
+      metadataPolicy: None
 
 ---
 apiVersion: apps/v1
@@ -246,6 +248,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
+      metadataPolicy: None
       key: cert-paperless-buc-sh
 
 ---

--- a/gitops/paperless/paperless-app.yaml
+++ b/gitops/paperless/paperless-app.yaml
@@ -35,7 +35,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-secret
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: eso-paperless-credentials
@@ -43,13 +43,13 @@ spec:
   data:
   - secretKey: PAPERLESS_ADMIN_USER
     remoteRef:
-      key: access/static-cred
+      key: static-secrets
       property: cred_admin_user
       conversionStrategy: Default
       decodingStrategy: None
   - secretKey: PAPERLESS_ADMIN_PASSWORD
     remoteRef:
-      key: access/static-cred
+      key: static-secrets
       property: cred_admin_password
       conversionStrategy: Default
       decodingStrategy: None
@@ -237,7 +237,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-cluster
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: cert-paperless-buc-sh
@@ -246,7 +246,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
-      key: cert/cert-paperless-buc-sh
+      key: cert-paperless-buc-sh
 
 ---
 apiVersion: networking.k8s.io/v1

--- a/gitops/syncthing/syncthing-app.yaml
+++ b/gitops/syncthing/syncthing-app.yaml
@@ -37,7 +37,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-secret
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: eso-syncthing-credentials
@@ -45,14 +45,14 @@ spec:
   data:
   - secretKey: ADMIN_USER
     remoteRef:
-      key: access/static-cred
+      key: static-secrets
       property: cred_admin_user
       conversionStrategy: Default
       decodingStrategy: None
       metadataPolicy: None
   - secretKey: ADMIN_PASSWORD
     remoteRef:
-      key: access/static-cred
+      key: static-secrets
       property: cred_admin_password
       conversionStrategy: Default
       decodingStrategy: None
@@ -66,7 +66,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-secret
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: eso-syncthing-application
@@ -75,7 +75,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
-      key: access/syncthing
+      key: syncthing-secrets
       metadataPolicy: None
 
 ---
@@ -219,7 +219,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-cluster
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: cert-syncthing-buc-sh
@@ -228,7 +228,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
-      key: cert/cert-syncthing-buc-sh
+      key: cert-syncthing-buc-sh
       metadataPolicy: None
 
 ---

--- a/gitops/unused_nginx/deployment.yaml
+++ b/gitops/unused_nginx/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: vault-approle-cluster
+    name: k8s-evergreen
     kind: ClusterSecretStore
   target:
     name: cert-cloud-buc-sh
@@ -15,7 +15,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
-      key: cert/cert-secure-http-buc-sh
+      key: cert-secure-http-buc-sh
 
 ---
 apiVersion: apps/v1

--- a/gitops/unused_nginx/deployment.yaml
+++ b/gitops/unused_nginx/deployment.yaml
@@ -15,6 +15,7 @@ spec:
   - extract:
       conversionStrategy: Default
       decodingStrategy: None
+      metadataPolicy: None
       key: cert-secure-http-buc-sh
 
 ---

--- a/talos/talos-merge.yaml
+++ b/talos/talos-merge.yaml
@@ -49,7 +49,7 @@ cluster:
   #   https://www.talos.dev/v1.3/kubernetes-guides/configuration/deploy-metrics-server/
   - https://raw.githubusercontent.com/alex1989hu/kubelet-serving-cert-approver/main/deploy/standalone-install.yaml
   inlineManifests:
-  - name: eso-secret-id
+  - name: eso-k8s-token
     contents:  ""
   - name: infra-argocd
     contents: ""


### PR DESCRIPTION
The central cluster no longer hosts Vault for fetching secrets. Instead we ust ExternalSecretsOpertaor to fetch secrets directly from the central clusters Kubernetes-API

* Replace vault-token with a K8s ServiceAccount token
* Update Talos config to create a secret with the new token
* Configure a ClusterSecretStore for the central cluster
* Change the ExternalSecret definitions to use the new ClusterSecretStore: Envoy, R2, Grafana, NTFY, Paperless and Syncthing
* Add TLS Certificate for "prod-console.buc.sh"